### PR TITLE
🐛 Fixed Github token name for package publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -42,4 +42,4 @@ jobs:
       - run: npm i
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_PKG_TOKEN}}


### PR DESCRIPTION
Changed Github token name from GITHUB_TOKEN to GITHUB_PKG_TOKEN for package publishing.